### PR TITLE
Add .well-known/openid-configuration endpoint and issuer public key for Pelican

### DIFF
--- a/static/.well-known/jwks.json
+++ b/static/.well-known/jwks.json
@@ -1,0 +1,13 @@
+{
+    "keys": [
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "3cfa",
+            "kty": "EC",
+            "use": "sig",
+            "x": "-QKhuhCu5U2Q8vgace0trtAtrNFW3Jt8dZoyX4HAkvc=",
+            "y": "vYtQT1B-cH_QG-K4Bgl16V8WkhOkKle4WWASzZ5N104="
+        }
+    ]
+}

--- a/static/.well-known/openid-configuration
+++ b/static/.well-known/openid-configuration
@@ -1,0 +1,4 @@
+{
+    "issuer": "https://sagecontinuum.org",
+    "jwks_uri": "https://sagecontinuum.org/.well-known/jwks.json"
+}


### PR DESCRIPTION
This PR just adds a static .well-known/openid-configuration endpoint and a scitokens public key for Pelican to use.