### PR TITLE
Update image search labs page

### DIFF
--- a/labs/image-search.md
+++ b/labs/image-search.md
@@ -86,5 +86,9 @@ As our object database continues to grow, the challenge of finding the right ima
 
 If you’re working on something similar or curious to dive deeper, feel free to reach out.
 
+## Publication
+
+This work was presented at [USRSE'25](https://us-rse.org/usrse25). For a high-level overview of the system architecture and motivation, see the [official poster](https://doi.org/10.5281/zenodo.17237284): *Searching Sage: AI-Powered Image Retrieval on a Nationwide Edge Computing Cyberinfrastructure*.
+
 <LabButtons id="image-search" />
 

--- a/labs/image-search.md
+++ b/labs/image-search.md
@@ -34,6 +34,8 @@ This project is all about **hybrid search** — combining **vector-based** and *
 
 Why all this? Because combining these techniques helps you go beyond surface-level matching — it helps find the *right* image even if the words in the query aren’t an exact match to the caption.
 
+> **Note:** Individual components (captioning models, embedding models, rerankers, and so on) are interchangeable — the deployed system may use updated versions of those listed above, but the **pipeline** stays the same. For the latest models and services in use, see the [Github Repository](https://github.com/waggle-sensor/sage-nrp-image-search).
+
 ## The Tech Stack & Pipeline
 
 Here’s how it all fits together:

--- a/labs/labsData.tsx
+++ b/labs/labsData.tsx
@@ -38,7 +38,7 @@ export const labProjects: LabProject[] = [
       external: true
     },
     readMoreUrl: './labs/image-search',
-    githubUrl: 'https://github.com/waggle-sensor/sage-vectordb-example'
+    githubUrl: 'https://github.com/waggle-sensor/sage-nrp-image-search'
   },
   {
     id: 'sage-mcp',


### PR DESCRIPTION
This pull request updates the documentation and metadata for the image search lab project to reflect the latest system components, publication, and repository information. The main changes ensure users are directed to the most current resources and are informed about the project's recent presentation.

**Documentation updates:**

* Added a note in `labs/image-search.md` clarifying that individual components (captioning models, embedding models, rerankers, etc.) are interchangeable, and provided a link to the latest GitHub repository for up-to-date information.
* Added a new "Publication" section in `labs/image-search.md` with details about the project’s presentation at USRSE'25 and a link to the official poster and DOI.

**Metadata update:**

* Updated the `githubUrl` in `labs/labsData.tsx` for the image search project to point to the new repository `sage-nrp-image-search` instead of the older `sage-vectordb-example`.